### PR TITLE
docs: add missing marshalls to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,10 @@ Note: `npq` by default will offload all commands and their arguments to the `npm
 | Marshall Name | Description | Notes
 | --- | --- | ---
 | age | Will show a warning for a package if its age on npm is less than 22 days | Checks a package creation date, not a specific version
+| author | Will show a warning if a package has been found without an author field | Checks the latest version for an author
 | downloads | Will show a warning for a package if its download count in the last month is less than 20
 | readme | Will show a warning if a package has no README or it has been detected as a security placeholder package by npm staff
+| repo | Will show a warning if a package has been found without a valid and working repository URL | Checks the latest version for a repository URL
 | scripts | Will show a warning if a package has a pre/post install script which could potentially be malicious
 | snyk | Will show a warning if a package has been found with vulnerabilities in snyk's database | For snyk to work you need to either have the `snyk` npm package installed with a valid api token, or make the token available in the SNYK_TOKEN environment variable, and npq will use it
 | license | Will show a warning if a package has been found without a license field | Checks the latest version for a license


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add descriptions for the `author` and `repo` marshalls to the README.

## Motivation and Context
I was looking for a way to disable the `author` warning and noticed it's supported but not documented.

## How Has This Been Tested?
Running `MARSHALL_DISABLE_AUTHOR=1 npm i package-without-author`.

## Screenshots (if appropriate):
<details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/13774309/154107195-aadb901d-241a-4f78-98e1-817b5298fe88.png)

</details>



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation (if required).
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
